### PR TITLE
fix: update k8s version in tke

### DIFF
--- a/hosted/tke/helper/helper_cluster.go
+++ b/hosted/tke/helper/helper_cluster.go
@@ -45,7 +45,7 @@ func ListTKEAllVersions(client *rancher.Client) (allVersions []string, err error
 		return
 	}
 
-	allVersions = []string{"1.32.2", "1.30.0", "1.28.3"}
+	allVersions = []string{"1.34.1", "1.32.2", "1.30.0"}
 
 	switch {
 	case strings.Contains(serverVersion, "2.12"):

--- a/hosted/tke/p0/p0_suite_test.go
+++ b/hosted/tke/p0/p0_suite_test.go
@@ -51,6 +51,7 @@ var _ = ReportAfterEach(func(report SpecReport) { Qase(testCaseID, report) })
 func p0UpgradeK8sVersionChecks(c *management.Cluster, client *rancher.Client, name string) {
 	helpers.ClusterIsReadyChecks(c, client, name)
 
+	// tke upgrade k8s version to 1.34.1 is not available yet, it should change to false when it is ready.
 	upgradeTo, err := tkehelper.GetK8sVersion(client, true)
 	Expect(err).To(BeNil())
 	GinkgoLogr.Info(fmt.Sprintf("Upgrading TKE cluster to version %s", upgradeTo))


### PR DESCRIPTION
### What does this PR do?
update k8s version in tke.
But 1.30.0 is not compatable with Rancher 2.13，and upgrade to 1.34.1 is not available in tke, so the only available version is 1.32.2.

### Checklist:
- [x] Squashed commits into logical changes
- [ ] Documentation
- [ ] GitHub Actions (if applicable)

### Special notes for your reviewer:
